### PR TITLE
Add appveyor CI build for Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+environment:
+  nodejs_version: "6" # 7 not yet supported
+platform:
+  - x86
+  - x64
+install:
+  # Get the latest stable version of Node.js
+  - ps: Install-Product node $env:nodejs_version $env:platform
+test_script:
+  - node --version
+  - npm --version
+  - npm install
+build: off # Required to make appveyor behave


### PR DESCRIPTION
Just builds on Windows in x86 and x64 to make sure there aren't any silly failures.

You will need to add Appveyor to the repo. Sample build: https://ci.appveyor.com/project/knpwrs/electron-vibrancy/build/1.0.19